### PR TITLE
Remove commented-out student bodies link from Navbar and adjust image…

### DIFF
--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -8,7 +8,7 @@ import { ChevronDown } from "lucide-react"
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/tree", label: "Senate Structure" },
-  { href: "/societies", label: "Student bodies" },
+  // { href: "/societies", label: "Student bodies" },
   {
     href: "/senate",
     label: "Student Body Directory",

--- a/components/shared/PersonCard.tsx
+++ b/components/shared/PersonCard.tsx
@@ -36,7 +36,7 @@ const PersonCard: React.FC<{ person: Person }> = ({ person }) => {
           src={person.image}
           alt={person.name}
           fill
-          className="object-cover grayscale group-hover:grayscale-0 transition-all duration-500 ease-in-out group-hover:scale-110"
+          className="object-cover transition-all duration-500 ease-in-out group-hover:scale-110"
           onError={(e) => {
             // Fallback to a default image if the provided one fails
             (e.target as HTMLImageElement).onerror = null; 


### PR DESCRIPTION
This pull request includes minor UI adjustments to the navigation and person card components. The main changes are the removal of the grayscale effect on person images and the temporary disabling of the "Student bodies" navigation link.

Navigation updates:

* Commented out the "Student bodies" link in the `navLinks` array in `Navbar.tsx`, effectively removing it from the navigation bar.

UI improvements:

* Removed the grayscale effect from person images in `PersonCard.tsx`, so images now display in full color by default.… class in PersonCard for improved styling